### PR TITLE
added constants in C

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -269,6 +269,10 @@ syn match cBraces display "[{}]"
 syn keyword cBoolean true false TRUE FALSE
 
 
+" Constants
+syn match cConstant "\v<[A-Z_][A-Z0-9_]*>"
+
+
 " Links
 hi def link cFunction Function
 hi def link cIdentifier Identifier
@@ -276,4 +280,5 @@ hi def link cDelimiter Delimiter
 " foldmethod=syntax fix, courtesy of Ivan Freitas
 hi def link cBraces Delimiter
 hi def link cBoolean Boolean
+hi def link cConstant Constant
 


### PR DESCRIPTION
Added constants in C. This instantly increased readability, as caps kind of overpower regular identifiers.

Examples of "constants":
- `SOME_IDENTIFIER`
- `_WIN32`
- `FOO_BAR_QUX_QIX_12335___`
- `_123`

Examples of non-constants:
- `some_constant`
- `CONFIGURATION_Debug`
- `12345`

Just to be extra clear. :+1:

Here is an example of constants and identifiers playing nicely.

<img width="470" alt="screen shot 2015-09-05 at 7 22 33 pm" src="https://cloud.githubusercontent.com/assets/885648/9701948/84ac3bfa-5403-11e5-932d-35be4625460d.png">
