### PR TITLE
Fix project's language classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent fixtures from showing in diffs or skewing language stats
+test/* linguist-vendored


### PR DESCRIPTION
Currently, GitHub recognises this repository as a Yacc project due to [`test/example.yy`](https://github.com/justinmk/vim-syntax-extra/blob/ec6b2cc027d21b91b611de0d402ab0930cedc9b7/test/example.yy) being the largest file tracked in the codebase. The classification library used on the site has a [mechanism](https://github.com/github/linguist#overrides) for excluding specific files from usage stats; merging this PR will make GitHub classify the repo as Vim script.