### PR TITLE
Fixed and improved lex.vim (second update)

### DIFF
--- a/after/syntax/lex.vim
+++ b/after/syntax/lex.vim
@@ -1,135 +1,186 @@
 " Vim syntax file
 " Language:	Lex
-" Maintainer:	Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Mar 26, 2012
-" Version:	13	ASTRO-ONLY
-" URL:	http://www.drchip.org/astronaut/vim/index.html#vimlinks_syntax
-"
-" Option:
-"   lex_uses_cpp : if this variable exists, then C++ is loaded rather than C
+" Maintainer:	Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
+" Contributor:	Robert A. van Engelen <engelen@acm.org>
+" Last Change:	Feb 3, 2020
+" Version:	19
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
-  finish
-endif
-
-" Read the C/C++ syntax to start with
-if version >= 600
-  if exists("lex_uses_cpp")
-    runtime! syntax/cpp.vim
-  else
-    runtime! syntax/c.vim
+" Read the C++ syntax to start with
+let s:Cpath= fnameescape(expand("<sfile>:p:h")."/cpp.vim")
+if !filereadable(s:Cpath)
+ for s:Cpath in split(globpath(&rtp,"syntax/cpp.vim"),"\n")
+  if filereadable(fnameescape(s:Cpath))
+   let s:Cpath= fnameescape(s:Cpath)
+   break
   endif
-  unlet b:current_syntax
-else
-  if exists("lex_uses_cpp")
-    so <sfile>:p:h/cpp.vim
-  else
-    so <sfile>:p:h/c.vim
-  endif
+ endfor
 endif
+exe "syn include @lexCcode ".s:Cpath
 
 " --- ========= ---
 " --- Lex stuff ---
 " --- ========= ---
 
-" Options Section
-syn match lexOptions '^%\s*option\>.*$' contains=lexPatString
+" lexAbbrevBlock
+" %%
+" lexPatBlock
+" %%
+" lexFinalCodeBlock
+"
+" --- ======= ---
+" --- Example ---
+" --- ======= ---
+"
+"   // this is a valid lex file
+"   // indented initial code block
+"   #include <stdlib.h>
+" %{
+" // initial code block
+" #include <stdio.h>
+" const char *sep = "";
+" %}
+" %option outfile="scanner.c" noyywrap nodefault
+" %x COMMENT
+" id      [A-Za-z_][A-Za-z0-9_]*
+" %%
+"   // indented initial action code block
+"   printf("BEGIN");
+" {id}    printf("%s%s", sep, yytext); sep = "";
+" .       |
+" \n      { sep = "\n"; }
+" "/*"    { BEGIN COMMENT; }
+" "//".*  { }
+" <COMMENT>{
+" "*/"    { BEGIN INITIAL; }
+" .|\n    
+" }
+" <*><<EOF>> { // end of file
+"              printf("\nEND\n");
+"              yyterminate();
+"            }
+" %%
+" void scan()
+" {
+"   while (yylex())
+"     continue;
+" }
+" /* main program */
+" int main()
+" { 
+"   scan();
+" }   
 
-"I'd prefer to use lex.* , but vim doesn't handle forward definitions yet
-syn cluster lexListGroup		contains=lexAbbrvBlock,lexAbbrv,lexAbbrv,lexAbbrvRegExp,lexInclude,lexPatBlock,lexPat,lexBrace,lexPatString,lexPatTag,lexPatTag,lexPatComment,lexPatCodeLine,lexMorePat,lexPatSep,lexSlashQuote,lexPatCode,cInParen,cUserLabel,cOctalZero,cCppSkip,cErrInBracket,cErrInParen,cOctalError,cCppOut2,cCommentStartError,cParenError
-syn cluster lexListPatCodeGroup	contains=lexAbbrvBlock,lexAbbrv,lexAbbrv,lexAbbrvRegExp,lexInclude,lexPatBlock,lexPat,lexBrace,lexPatTag,lexPatTag,lexPatTagZoneStart,lexPatComment,lexPatCodeLine,lexMorePat,lexPatSep,lexSlashQuote,cInParen,cUserLabel,cOctalZero,cCppSkip,cErrInBracket,cErrInParen,cOctalError,cCppOut2,cCommentStartError,cParenError
+" Initial code block prior to the Abbreviations Section
+if has("folding")
+ syn region lexInitialCodeBlock	fold	start="^\s\+"	end="^\S"me=e-1	nextgroup=lexAbbrvBlock	contains=@lexCcode
+else
+ syn region lexInitialCodeBlock		start="^\s\+"	end="^\S"me=e-1	nextgroup=lexAbbrvBlock	contains=@lexCcode
+endif
 
 " Abbreviations Section
 if has("folding")
- syn region lexAbbrvBlock	fold start="^\(\h\+\s\|%{\)"	end="^\ze%%$"	skipnl	nextgroup=lexPatBlock contains=lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
+ syn region lexAbbrvBlock	fold	start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
 else
- syn region lexAbbrvBlock	start="^\(\h\+\s\|%{\)"	end="^\ze%%$"	skipnl	nextgroup=lexPatBlock contains=lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
+ syn region lexAbbrvBlock		start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
 endif
-syn match  lexAbbrv		"^\I\i*\s"me=e-1			skipwhite	contained nextgroup=lexAbbrvRegExp
-syn match  lexAbbrv		"^%[sx]"					contained
-syn match  lexAbbrvRegExp	"\s\S.*$"lc=1				contained nextgroup=lexAbbrv,lexInclude
+syn match  lexOptions		"^%\a\+\(\s.*\|[^{]*\)$"				contains=lexOptionsEq,lexPatString,lexSlashQuote,lexBrace,lexSlashBrace
+syn match  lexOptionsEq		"="					skipwhite	contained
+syn match  lexAbbrv		"^\I\i*\s"me=e-1			skipwhite	contained	nextgroup=lexAbbrvPat
+syn match  lexAbbrvPat		"\s\S.*$"lc=1						contained	contains=lexPatAbbrv,lexPatString,lexSlashQuote,lexBrace,lexSlashBrace	nextgroup=lexAbbrv,lexInclude
+syn match  lexStartState		"^%\(xs\?\|s\)\(t\(a\(t\(e\?\)\?\)\?\)\?\)\?\(\s\+\I\i*\)\+\s*$"	contained
 if has("folding")
- syn region lexInclude	fold matchgroup=lexSep	start="^%{"	end="%}"	contained	contains=ALLBUT,@lexListGroup
- syn region lexAbbrvComment	fold			start="^\s\+/\*"	end="\*/"	contains=@Spell
- syn region lexStartState	fold matchgroup=lexAbbrv	start="^%\a\+"	end="$"	contained
+ syn region lexInclude		fold	matchgroup=lexSep	start="^%\a*{"	end="^%}"	contained	contains=@lexCcode,lexCFunctions
+ syn region lexAbbrvComment	fold				start="^\s*//"	end="$"		contains=@Spell
+ syn region lexAbbrvComment	fold				start="^\s*/\*"	end="\*/"	contains=@Spell
 else
- syn region lexInclude	matchgroup=lexSep		start="^%{"	end="%}"	contained	contains=ALLBUT,@lexListGroup
- syn region lexAbbrvComment				start="^\s\+/\*"	end="\*/"	contains=@Spell
- syn region lexStartState	matchgroup=lexAbbrv		start="^%\a\+"	end="$"	contained
+ syn region lexInclude			matchgroup=lexSep	start="^%\a*{"	end="^%}"	contained	contains=@lexCcode,lexCFunctions
+ syn region lexAbbrvComment					start="^\s*//"	end="$"		contains=@Spell
+ syn region lexAbbrvComment					start="^\s*/\*"	end="\*/"	contains=@Spell
 endif
 
 "%% : Patterns {Actions}
 if has("folding")
- syn region lexPatBlock	fold matchgroup=Todo	start="^%%$" matchgroup=Todo	end="^%%$"	skipnl	skipwhite	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatInclude
- syn region lexPat		fold			start=+\S+ skip="\\\\\|\\."	end="\s"me=e-1		contained nextgroup=lexMorePat,lexPatSep contains=lexPatTag,lexPatString,lexSlashQuote,lexBrace
- syn region lexPatInclude	fold matchgroup=lexSep	start="^%{"	end="%}"	contained	contains=lexPatCode
- syn region lexBrace	fold			start="\[" skip=+\\\\\|\\+	end="]"			contained
- syn region lexPatString	fold matchgroup=String	start=+"+	skip=+\\\\\|\\"+	matchgroup=String end=+"+	contained
+ syn region lexPatBlock		fold	matchgroup=Todo	start="^%%"	matchgroup=Todo	end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPat		fold			start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
+ syn region lexPatInclude	fold	matchgroup=lexSep	start="^%{"	end="^%}"	contained	contains=@lexCcode
+ syn region lexBrace		fold	matchgroup=Character    start="\["	skip="\\.\|\[:\a\+:\]\|\[\.\a\+\.\]\|\[=.=\]"	end="\]"	contained
+ syn region lexPatString	fold	matchgroup=String	start=+"+	skip=+\\\\\|\\"+	matchgroup=String	end=+"+	contained
 else
- syn region lexPatBlock	matchgroup=Todo		start="^%%$" matchgroup=Todo	end="^%%$"	skipnl	skipwhite	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatInclude
- syn region lexPat					start=+\S+ skip="\\\\\|\\."	end="\s"me=e-1		contained nextgroup=lexMorePat,lexPatSep contains=lexPatTag,lexPatString,lexSlashQuote,lexBrace
- syn region lexPatInclude	matchgroup=lexSep		start="^%{"	end="%}"	contained	contains=lexPatCode
- syn region lexBrace				start="\[" skip=+\\\\\|\\+	end="]"			contained
- syn region lexPatString	matchgroup=String		start=+"+	skip=+\\\\\|\\"+	matchgroup=String end=+"+	contained
+ syn region lexPatBlock			matchgroup=Todo	start="^%%"	matchgroup=Todo	end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPat					start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
+ syn region lexPatInclude		matchgroup=lexSep	start="^%{"	end="^%}"	contained	contains=@lexCcode
+ syn region lexBrace			matchgroup=Character    start="\["	skip="\\.\|\[:\a\+:\]\|\[\.\a\+\.\]\|\[=.=\]"	end="\]"	contained
+ syn region lexPatString		matchgroup=String	start=+"+	skip=+\\\\\|\\"+	matchgroup=String	end=+"+	contained
 endif
-syn match  lexPatTag	"^<\I\i*\(,\I\i*\)*>"			contained nextgroup=lexPat,lexPatTag,lexMorePat,lexPatSep
-syn match  lexPatTagZone	"^<\I\i*\(,\I\i*\)*>\s*\ze{"		contained nextgroup=lexPatTagZoneStart
-syn match  lexPatTag	+^<\I\i*\(,\I\i*\)*>*\(\\\\\)*\\"+		contained nextgroup=lexPat,lexPatTag,lexMorePat,lexPatSep
+syn match  lexPatAbbrv		"{\I\i*}"hs=s+1,he=e-1					contained
+syn match  lexPatTag		"^<\^\?\(\I\i*\|\*\)\(,\^\?\(\I\i*\|\*\)\)*>"		contained	nextgroup=lexPat,lexMorePat,lexPatSep,lexPatEnd
+syn match  lexPatTagZone	"^<\^\?\(\I\i*\|\*\)\(,\^\?\(\I\i*\|\*\)\)*>{"me=e-1	contained	nextgroup=lexPatTagZoneStart
+
 if has("folding")
- syn region  lexPatTagZoneStart matchgroup=lexPatTag	fold	start='{' end='}'	contained contains=lexPat,lexPatComment
- syn region lexPatComment	start="\s\+/\*" end="\*/"	fold	skipnl	contained contains=cTodo skipwhite nextgroup=lexPatComment,lexPat,@Spell
+ syn region lexPatTagZoneStart	fold	matchgroup=lexPatTag	start='{'	end='^}'	skipnl	skipwhite	contained	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPatComment	fold	start="//"	end="$"		skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
+ syn region lexPatComment	fold	start="/\*"	end="\*/"	skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
 else
- syn region  lexPatTagZoneStart matchgroup=lexPatTag		start='{' end='}'	contained contains=lexPat,lexPatComment
- syn region lexPatComment	start="\s\+/\*" end="\*/"		skipnl	contained contains=cTodo skipwhite nextgroup=lexPatComment,lexPat,@Spell
+ syn region lexPatTagZoneStart		matchgroup=lexPatTag		start='{'	end='^}'	skipnl	skipwhitecontained	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPatComment		start="//"	end="$"		skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
+ syn region lexPatComment		start="/\*"	end="\*/"	skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
 endif
-syn match  lexPatCodeLine	".*$"					contained contains=ALLBUT,@lexListGroup
-syn match  lexMorePat	"\s*|\s*$"			skipnl	contained nextgroup=lexPat,lexPatTag,lexPatComment
-syn match  lexPatSep	"\s\+"					contained nextgroup=lexMorePat,lexPatCode,lexPatCodeLine
+syn match  lexPatEnd		"\s*$"				skipnl	contained
+syn match  lexPatCodeLine	"[^{\[].*"				contained	contains=@lexCcode,lexCFunctions
+syn match  lexMorePat		"\s*|\s*$"			skipnl	contained	nextgroup=lexPat,lexPatTag,lexPatComment
+syn match  lexPatSep		"\s\+"					contained	nextgroup=lexMorePat,lexPatCode,lexPatCodeLine
 syn match  lexSlashQuote	+\(\\\\\)*\\"+				contained
+syn match  lexSlashBrace	+\(\\\\\)*\\\[+				contained
 if has("folding")
- syn region lexPatCode matchgroup=Delimiter start="{" end="}"	fold	skipnl contained contains=ALLBUT,@lexListPatCodeGroup
+ syn region lexPatCode		fold	matchgroup=Delimiter	start="{"	end="}"	skipnl	contained	contains=@lexCcode,lexCFunctions
 else
- syn region lexPatCode matchgroup=Delimiter start="{" end="}"		skipnl contained contains=ALLBUT,@lexListPatCodeGroup
+ syn region lexPatCode			matchgroup=Delimiter	start="{"	end="}"	skipnl	contained	contains=@lexCcode,lexCFunctions
 endif
 
-syn keyword lexCFunctions	BEGIN	input	unput	woutput	yyleng	yylook	yytext
-syn keyword lexCFunctions	ECHO	output	winput	wunput	yyless	yymore	yywrap
+" Final code block
+syn region lexFinalCodeBlock	matchgroup=Todo	start="^%%"	end="\%$"	contained	contains=@lexCcode
+
+" Lex "functions" which may appear in C/C++ code blocks
+syn keyword lexCFunctions	BEGIN	ECHO	REJECT	yytext	YYText	yyleng	YYLeng	yymore	yyless	yywrap	yylook
+syn keyword lexCFunctions	yyrestart	yyterminate	yylineno	yycolumno	yyin	yyout
+syn keyword lexCFunctions	input	unput	output	        winput	        wunput	        woutput
+syn keyword lexCFunctions	yyinput	yyunput	yyoutput	yywinput	yywunput	yywoutput
 
 " <c.vim> includes several ALLBUTs; these have to be treated so as to exclude lex* groups
-syn cluster cParenGroup	add=lex.*
+syn cluster cParenGroup	        add=lex.*
 syn cluster cDefineGroup	add=lex.*
 syn cluster cPreProcGroup	add=lex.*
-syn cluster cMultiGroup	add=lex.*
+syn cluster cMultiGroup	        add=lex.*
 
 " Synchronization
 syn sync clear
-syn sync minlines=300
+syn sync minlines=500
 syn sync match lexSyncPat	grouphere  lexPatBlock	"^%[a-zA-Z]"
 syn sync match lexSyncPat	groupthere lexPatBlock	"^<$"
-syn sync match lexSyncPat	groupthere lexPatBlock	"^%%$"
+syn sync match lexSyncPat	groupthere lexPatBlock	"^%%"
 
 " The default highlighting.
-hi def link lexAbbrvComment	lexPatComment
-hi def link lexBrace	lexPat
-hi def link lexPatTagZone	lexPatTag
-hi def link lexSlashQuote	lexPat
-
-hi def link lexAbbrvRegExp	Macro
-hi def link lexAbbrv	SpecialChar
-hi def link lexCFunctions	Function
-hi def link lexMorePat	SpecialChar
-hi def link lexOptions	PreProc
-hi def link lexPatComment	Comment
-hi def link lexPat		Function
-hi def link lexPatString	Function
-hi def link lexPatTag	Special
-hi def link lexSep		Delimiter
-hi def link lexStartState	Statement
+if !exists("skip_lex_syntax_inits")
+ hi def link lexAbbrvComment	lexPatComment
+ hi def link lexAbbrvPat	lexPat
+ hi def link lexAbbrv	        Special
+ hi def link lexBrace	        lexPat
+ hi def link lexCFunctions	PreProc
+ hi def link lexMorePat	        Special
+ hi def link lexOptions	        PreProc
+ hi def link lexOptionsEq	Operator
+ hi def link lexPatComment	Comment
+ hi def link lexPat		Function
+ hi def link lexPatString	lexPat
+ hi def link lexPatAbbrv	Special
+ hi def link lexPatTag	        Statement
+ hi def link lexPatTagZone	lexPatTag
+ hi def link lexSep		Delimiter
+ hi def link lexSlashQuote	lexPat
+ hi def link lexSlashBrace	lexPat
+ hi def link lexStartState	lexPatTag
+endif
 
 let b:current_syntax = "lex"
 
-" vim:ts=10
+" vim:ts=8

--- a/after/syntax/lex.vim
+++ b/after/syntax/lex.vim
@@ -2,8 +2,13 @@
 " Language:	Lex
 " Maintainer:	Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " Contributor:	Robert A. van Engelen <engelen@acm.org>
-" Last Change:	Feb 3, 2020
-" Version:	19
+" Last Change:	Mar 19, 2020
+" Version:	20
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
 
 " Read the C++ syntax to start with
 let s:Cpath= fnameescape(expand("<sfile>:p:h")."/cpp.vim")
@@ -21,11 +26,11 @@ exe "syn include @lexCcode ".s:Cpath
 " --- Lex stuff ---
 " --- ========= ---
 
-" lexAbbrevBlock
+" Definitions
 " %%
-" lexPatBlock
+" Rules
 " %%
-" lexFinalCodeBlock
+" User Code
 "
 " --- ======= ---
 " --- Example ---
@@ -70,44 +75,39 @@ exe "syn include @lexCcode ".s:Cpath
 "   scan();
 " }   
 
-" Initial code block prior to the Abbreviations Section
+" Definitions Section with initial code blocks, abbreviations, options, states
 if has("folding")
- syn region lexInitialCodeBlock	fold	start="^\s\+"	end="^\S"me=e-1	nextgroup=lexAbbrvBlock	contains=@lexCcode
+ syn region lexAbbrvBlock	fold	start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInitialCodeBlock,lexInclude,lexAbbrvComment,lexStartState
 else
- syn region lexInitialCodeBlock		start="^\s\+"	end="^\S"me=e-1	nextgroup=lexAbbrvBlock	contains=@lexCcode
-endif
-
-" Abbreviations Section
-if has("folding")
- syn region lexAbbrvBlock	fold	start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
-else
- syn region lexAbbrvBlock		start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInclude,lexAbbrvComment,lexStartState
+ syn region lexAbbrvBlock		start="^\S"	end="^\ze%%"	skipnl	nextgroup=lexPatBlock	contains=lexOptions,lexAbbrv,lexInitialCodeBlock,lexInclude,lexAbbrvComment,lexStartState
 endif
 syn match  lexOptions		"^%\a\+\(\s.*\|[^{]*\)$"				contains=lexOptionsEq,lexPatString,lexSlashQuote,lexBrace,lexSlashBrace
 syn match  lexOptionsEq		"="					skipwhite	contained
 syn match  lexAbbrv		"^\I\i*\s"me=e-1			skipwhite	contained	nextgroup=lexAbbrvPat
 syn match  lexAbbrvPat		"\s\S.*$"lc=1						contained	contains=lexPatAbbrv,lexPatString,lexSlashQuote,lexBrace,lexSlashBrace	nextgroup=lexAbbrv,lexInclude
-syn match  lexStartState		"^%\(xs\?\|s\)\(t\(a\(t\(e\?\)\?\)\?\)\?\)\?\(\s\+\I\i*\)\+\s*$"	contained
+syn match  lexStartState	"^%\(xs\?\|s\)\(t\(a\(t\(e\?\)\?\)\?\)\?\)\?\(\s\+\I\i*\)\+\s*$"	contained
 if has("folding")
+ syn region lexInitialCodeBlock	fold				start="^\s\+"	end="^\S"me=e-1			contains=@lexCcode
  syn region lexInclude		fold	matchgroup=lexSep	start="^%\a*{"	end="^%}"	contained	contains=@lexCcode,lexCFunctions
  syn region lexAbbrvComment	fold				start="^\s*//"	end="$"		contains=@Spell
  syn region lexAbbrvComment	fold				start="^\s*/\*"	end="\*/"	contains=@Spell
 else
+ syn region lexInitialCodeBlock					start="^\s\+"	end="^\S"me=e-1			contains=@lexCcode
  syn region lexInclude			matchgroup=lexSep	start="^%\a*{"	end="^%}"	contained	contains=@lexCcode,lexCFunctions
  syn region lexAbbrvComment					start="^\s*//"	end="$"		contains=@Spell
  syn region lexAbbrvComment					start="^\s*/\*"	end="\*/"	contains=@Spell
 endif
 
-"%% : Patterns {Actions}
+" Rules Section with patterns and actions
 if has("folding")
- syn region lexPatBlock		fold	matchgroup=Todo	start="^%%"	matchgroup=Todo	end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
- syn region lexPat		fold			start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
+ syn region lexPatBlock		fold	matchgroup=Todo	        start="^%%"	matchgroup=Todo	        end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPat		fold			        start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
  syn region lexPatInclude	fold	matchgroup=lexSep	start="^%{"	end="^%}"	contained	contains=@lexCcode
  syn region lexBrace		fold	matchgroup=Character    start="\["	skip="\\.\|\[:\a\+:\]\|\[\.\a\+\.\]\|\[=.=\]"	end="\]"	contained
  syn region lexPatString	fold	matchgroup=String	start=+"+	skip=+\\\\\|\\"+	matchgroup=String	end=+"+	contained
 else
- syn region lexPatBlock			matchgroup=Todo	start="^%%"	matchgroup=Todo	end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
- syn region lexPat					start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
+ syn region lexPatBlock			matchgroup=Todo	        start="^%%"	matchgroup=Todo	        end="^\ze%%"	skipnl	skipwhite	nextgroup=lexFinalCodeBlock	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPat					        start="\S"	skip="\\\\\|\\\s"	end="\ze\(\s*$\|\s\+\(\h\|{\W\|{$\|[-+*]\|//\|/\*\)\)"	skipwhite	contained nextgroup=lexMorePat,lexPatSep,lexPatEnd      contains=lexPatTag,lexPatString,lexSlashQuote,lexPatAbbrv,lexBrace,lexSlashBrace
  syn region lexPatInclude		matchgroup=lexSep	start="^%{"	end="^%}"	contained	contains=@lexCcode
  syn region lexBrace			matchgroup=Character    start="\["	skip="\\.\|\[:\a\+:\]\|\[\.\a\+\.\]\|\[=.=\]"	end="\]"	contained
  syn region lexPatString		matchgroup=String	start=+"+	skip=+\\\\\|\\"+	matchgroup=String	end=+"+	contained
@@ -117,7 +117,7 @@ syn match  lexPatTag		"^<\^\?\(\I\i*\|\*\)\(,\^\?\(\I\i*\|\*\)\)*>"		contained	n
 syn match  lexPatTagZone	"^<\^\?\(\I\i*\|\*\)\(,\^\?\(\I\i*\|\*\)\)*>{"me=e-1	contained	nextgroup=lexPatTagZoneStart
 
 if has("folding")
- syn region lexPatTagZoneStart	fold	matchgroup=lexPatTag	start='{'	end='^}'	skipnl	skipwhite	contained	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
+ syn region lexPatTagZoneStart	fold	matchgroup=lexPatTag	start='{\s*$'	end='^}'	skipnl	skipwhite	contained	contains=lexPatTag,lexPatTagZone,lexPatComment,lexPat,lexPatSep,lexPatInclude
  syn region lexPatComment	fold	start="//"	end="$"		skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
  syn region lexPatComment	fold	start="/\*"	end="\*/"	skipnl	contained	contains=cTodo	skipwhite	nextgroup=lexPatComment,lexPat,@Spell
 else
@@ -137,10 +137,10 @@ else
  syn region lexPatCode			matchgroup=Delimiter	start="{"	end="}"	skipnl	contained	contains=@lexCcode,lexCFunctions
 endif
 
-" Final code block
+" User Code Section with final code block
 syn region lexFinalCodeBlock	matchgroup=Todo	start="^%%"	end="\%$"	contained	contains=@lexCcode
 
-" Lex "functions" which may appear in C/C++ code blocks
+" Lex macros which may appear in C/C++ code blocks
 syn keyword lexCFunctions	BEGIN	ECHO	REJECT	yytext	YYText	yyleng	YYLeng	yymore	yyless	yywrap	yylook
 syn keyword lexCFunctions	yyrestart	yyterminate	yylineno	yycolumno	yyin	yyout
 syn keyword lexCFunctions	input	unput	output	        winput	        wunput	        woutput


### PR DESCRIPTION
This update fixes highlighting of start condition scope with pattern starting with `{`. A regex pattern that starts with a `{` should not open a start condition scope.

With this update and the previous, fixes were applied to correct the following issues:

- Start condition states with a scope of the form `<state>{ ... }` are not recognized correctly, leading to highlighting errors below it such as `%%` not being highlighted.
- Action code is highlighted when enclosed in braces `{...}` but otherwise its is not, which is inconsistent.
- Indented initial code blocks (instead of placed in `%{...%}`) are not recognized and are not highlighted.
- Indented initial action code blocks are not recognized and not highlighted correctly, which appear right after the first `%%` and in start condition scopes
- initial action code blocks in `%{...%}` are not recognized in start condition scopes `<state>{ ... }`.
- The start condition state `<*>` is not recognized and not highlighted.
- `//`-comments are not always recognized and highlighted.
- Rule actions after patterns are not always highlighted, such as `ECHO`, which is inconsistent.
- Final code block is not always highlighted correctly when start condition states with scopes are used.
- Literal string quotes `“...”` are not highlighted in abbreviation definitions, whereas in patterns they are highlighted.
- `%option` are highlighted inconsistently when used before or after initial code blocks (both places are valid).
- Also highlighting of state declarations `%s` and `%x` are inconsistent or not highlighted at all when placed before initial code blocks.
- `%top{` is not recognized, which should be the same as a `%{` block, in principle any `%name{` should be recognized.